### PR TITLE
ARC: Add automake to the list of dependencies

### DIFF
--- a/doc/README.ARC
+++ b/doc/README.ARC
@@ -129,7 +129,7 @@ Download and install OpenOCD on Ubuntu 10.04 build host (32bits Intel)
 
   $> sudo apt-get install libftdi-dev libftdi1 libtool git-core asciidoc \
        build-essential flex bison \
-       libgmp3-dev libmpfr-dev autoconf \
+       libgmp3-dev libmpfr-dev autoconf automake \
        texinfo libncurses5-dev libexpat1 libexpat1-dev \
        tk tk8.4 tk8.4-dev
 


### PR DESCRIPTION
Ubuntu package 'automake' is required to build OpenOCD (specifically to make 'bootstrap') but it was missing from ARC readme file. I guess that at some point automake was a dependency for a libtool, autoconfigure or build-essential, but as of Ubuntu 13.04 that is not the case, so I've added an explicit mention of this package to readme.

Signed-off-by: Anton Kolesov akolesov@synopsys.com
