### PR TITLE
gdb_server: Do not set gdb_con->sync to true for new connections

### DIFF
--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -757,7 +757,7 @@ static int gdb_new_connection(struct connection *connection)
 	gdb_connection->closed = 0;
 	gdb_connection->busy = 0;
 	gdb_connection->noack_mode = 0;
-	gdb_connection->sync = true;
+	gdb_connection->sync = false;
 	gdb_connection->mem_write_error = false;
 	gdb_connection->attached = true;
 


### PR DESCRIPTION
In OpenOCD there is a command "monitor gdb_sync" which makes next stepi command to be ignored while GDB still will get an updated target state. This command sets gdb_connection->sync field to true to notify that stepi should be ignored. This field is set to true for all new connection and is set to false after first "continue" command. However if first resume command is stepi/nexti then it will be ignored and result will confuse GDB client, it will report that target received signal SIGINT. This patch sets this field to false for new connections, thus stepi/nexti will work properly when it is a first resume command.

Signed-off-by: Anton Kolesov akolesov@synopsys.com
