### PR TITLE
ARC: Optimize writes and reads of registers

### DIFF
--- a/src/target/arc_jtag.h
+++ b/src/target/arc_jtag.h
@@ -79,11 +79,19 @@ int arc_jtag_read_core_reg(struct arc_jtag *jtag_info, uint32_t addr,
 	uint32_t *value);
 int arc_jtag_write_core_reg(struct arc_jtag *jtag_info, uint32_t addr,
 	uint32_t *value);
+int arc_jtag_read_core_reg_bulk(struct arc_jtag *jtag_info,
+	uint32_t *values, unsigned int count);
+int arc_jtag_write_core_reg_bulk(struct arc_jtag *jtag_info, uint32_t *value,
+	unsigned int count);
 
 int arc_jtag_read_aux_reg(struct arc_jtag *jtag_info, uint32_t addr,
 	uint32_t *value);
 int arc_jtag_write_aux_reg(struct arc_jtag *jtag_info, uint32_t addr,
 	uint32_t *value);
+int arc_jtag_read_aux_reg_bulk(struct arc_jtag *jtag_info, uint32_t *addr,
+	uint32_t *value, unsigned int count);
+int arc_jtag_write_aux_reg_bulk(struct arc_jtag *jtag_info, uint32_t *addr,
+	uint32_t *value, unsigned int count);
 
 int arc_jtag_status(struct arc_jtag *jtag_info, uint32_t *value);
 int arc_jtag_idcode(struct arc_jtag *jtag_info, uint32_t *value);


### PR DESCRIPTION
When saving/restoring context all core and auxiliary registers are
read/written. This patch serializes those actions, reducing amount of
JTAG operations, and thus reducing required time. Previously each
register was written in a separate JTAG transaction and whole operation
on context was taking around 2100 ms. After this patch it takes around
600-700 ms to finish. This is still too slow but at least 3 times better
then before. Further optimizations in this area might be researched and
implemented.

Signed-off-by: Anton Kolesov akolesov@synopsys.com
