### PR TITLE
ARC: introduce configuration files for HS4x

### DIFF
--- a/tcl/board/snps_axs103_hs47D.cfg
+++ b/tcl/board/snps_axs103_hs47D.cfg
@@ -1,0 +1,36 @@
+#  Copyright (C) 2015-2016,2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+
+#
+# Synopsys DesignWare ARC AXS103 Software Development Platform (HS37D core)
+#
+
+# Configure JTAG cable
+# SDP has built-in FT2232 chip, which is similiar to Digilent HS-1, except that
+# it uses channgel B for JTAG, instead of channel A.
+source [find interface/ftdi/snps_sdp.cfg]
+adapter_khz 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_axc003_hs47D.cfg]
+
+# Initialize
+init
+reset halt
+

--- a/tcl/board/snps_axs103_hs48.cfg
+++ b/tcl/board/snps_axs103_hs48.cfg
@@ -1,0 +1,36 @@
+#  Copyright (C) 2015-2016,2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+
+#
+# Synopsys DesignWare ARC AXS103 Software Development Platform (HS48x2 cores)
+#
+
+# Configure JTAG cable
+# SDP has built-in FT2232 chip, which is similiar to Digilent HS-1, except that
+# it uses channgel B for JTAG, instead of channel A.
+source [find interface/ftdi/snps_sdp.cfg]
+adapter_khz 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_axc003_hs48.cfg]
+
+# Initialize
+init
+reset halt
+

--- a/tcl/target/snps_axc003_hs47D.cfg
+++ b/tcl/target/snps_axc003_hs47D.cfg
@@ -1,0 +1,49 @@
+#  Copyright (C) 2015,2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#
+# AXC003 CPU card for the AXS103.
+#
+# This configuration is for HS47D.
+#
+
+source [find cpu/arc/hs.tcl]
+
+set _coreid 0
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+
+# On-chip SRAM has size of 256KiB, mapped to 0x2000_0000.
+set _sram_addr 0x20000000
+set _sram_size 0x40000
+
+# CHIPNAME will be used to choose core family (600, 700 or EM). As far as
+# OpenOCD is concerned EM and HS are identical.
+set _CHIPNAME arc-em
+
+# For some reasons OpenOCD discovers JTAG TAPs in reverse order.
+
+set _TARGETNAME $_CHIPNAME.cpu
+jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -expected-id 0x201424b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+$_TARGETNAME configure -work-area-phys $_sram_addr -work-area-size $_sram_size
+$_TARGETNAME configure -event reset-assert "arc_hs_reset $_TARGETNAME"
+arc_hs_init_regs
+
+# vi:ft=tcl

--- a/tcl/target/snps_axc003_hs48.cfg
+++ b/tcl/target/snps_axc003_hs48.cfg
@@ -1,0 +1,70 @@
+#  Copyright (C) 2015,2019 Synopsys, Inc.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the
+#  Free Software Foundation, Inc.,
+
+#
+# AXC003 CPU card for the AXS103.
+#
+# This configuration is for dual core HS48 CPUs.
+#
+
+source [find cpu/arc/hs.tcl]
+
+set _coreid 0
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+
+# On-chip SRAM has size of 256KiB, mapped to 0x2000_0000.
+set _sram_addr 0x20000000
+set _sram_size 0x40000
+
+# CHIPNAME will be used to choose core family (600, 700 or EM). As far as
+# OpenOCD is concerned EM and HS are identical.
+set _CHIPNAME arc-em
+
+# For some reasons OpenOCD discovers JTAG TAPs in reverse order.
+
+# ARC HS48 core 2
+set _TARGETNAME $_CHIPNAME.cpu2
+jtag newtap $_CHIPNAME cpu2 -irlen 4 -ircapture 0x1 -expected-id 0x200424b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+$_TARGETNAME configure -work-area-phys $_sram_addr -work-area-size $_sram_size
+$_TARGETNAME configure -event reset-assert "arc_hs_reset $_TARGETNAME"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# Enable L2 cache support for core 2.
+$_TARGETNAME arc has-l2cache true
+
+# ARC HS48 core 1
+set _TARGETNAME $_CHIPNAME.cpu1
+jtag newtap $_CHIPNAME cpu1 -irlen 4 -ircapture 0x1 -expected-id 0x200024b1
+
+target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME
+$_TARGETNAME configure -coreid $_coreid
+$_TARGETNAME configure -dbgbase $_dbgbase
+$_TARGETNAME configure -work-area-phys $_sram_addr -work-area-size $_sram_size
+$_TARGETNAME configure -event reset-assert "arc_common_reset $_TARGETNAME"
+set _coreid [expr $_coreid + 1]
+set _dbgbase [expr 0x00000000 | ($_coreid << 13)]
+arc_hs_init_regs
+
+# Enable L2 cache support for core 1.
+$_TARGETNAME arc has-l2cache true
+
+# vi:ft=tcl


### PR DESCRIPTION
With recent AXS 103 1.3 release new firmware images(HS48x2 and HS47D) were introduced.
Lets add configure files for these these targets. 

These configs are pretty similar to hs38 and hs36 respectively, but we are not changing these configure file names to axs103_1/2_core due to possibility of occurrence of newer versions of HS cores, which would require specific options like "has-l2cache", etc.