### PR TITLE
[RFC] target/arc: Fix off-by-one error in arc_save_context()

### DIFF
--- a/src/target/arc.c
+++ b/src/target/arc.c
@@ -846,21 +846,17 @@ static int arc_save_context(struct target *target)
 	memset(aux_addrs, 0xff, aux_regs_size);
 
 	for (i = 0; i < MIN(arc->num_core_regs, regs_to_scan); i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
-		if (!reg->valid && reg->exist) {
-			core_addrs[core_cnt] = arc_reg->arch_num;
-			core_cnt += 1;
-		}
+		if (!reg->valid && reg->exist)
+			core_addrs[core_cnt++] = arc_reg->arch_num;
 	}
 
 	for (i = arc->num_core_regs; i < regs_to_scan; i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
-		if (!reg->valid && reg->exist) {
-			aux_addrs[aux_cnt] = arc_reg->arch_num;
-			aux_cnt += 1;
-		}
+		if (!reg->valid && reg->exist)
+			aux_addrs[aux_cnt++] = arc_reg->arch_num;
 	}
 
 	/* Read data from target. */
@@ -872,6 +868,7 @@ static int arc_save_context(struct target *target)
 			goto exit;
 		}
 	}
+
 	if (aux_cnt > 0) {
 		retval = arc_jtag_read_aux_reg(&arc->jtag_info, aux_addrs, aux_cnt, aux_values);
 		if (retval != ERROR_OK) {
@@ -882,32 +879,28 @@ static int arc_save_context(struct target *target)
 	}
 
 	/* Parse core regs */
-	core_cnt = 0;
 	for (i = 0; i < MIN(arc->num_core_regs, regs_to_scan); i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
 		if (!reg->valid && reg->exist) {
-			target_buffer_set_u32(target, reg->value, core_values[core_cnt]);
-			core_cnt += 1;
+			target_buffer_set_u32(target, reg->value, core_values[i]);
 			reg->valid = true;
 			reg->dirty = false;
 			LOG_DEBUG("Get core register regnum=%u, name=%s, value=0x%08" PRIx32,
-				i, arc_reg->name, core_values[core_cnt]);
+				i, arc_reg->name, core_values[i]);
 		}
 	}
 
 	/* Parse aux regs */
-	aux_cnt = 0;
 	for (i = arc->num_core_regs; i < regs_to_scan; i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
 		if (!reg->valid && reg->exist) {
-			target_buffer_set_u32(target, reg->value, aux_values[aux_cnt]);
-			aux_cnt += 1;
+			target_buffer_set_u32(target, reg->value, aux_values[i]);
 			reg->valid = true;
 			reg->dirty = false;
 			LOG_DEBUG("Get aux register regnum=%u, name=%s, value=0x%08" PRIx32,
-				i, arc_reg->name, aux_values[aux_cnt]);
+				i, arc_reg->name, aux_values[i]);
 		}
 	}
 


### PR DESCRIPTION
While not affecting the function's main purpose, an error has crept into arc_save_context() that results in logging wrong register values when the debug level is 3 or more. For instance, when debugging a trivial program and halting at entry to main, the following values are printed to the log:

Debug: 2868 5634 arc.c:955 arc_save_context(): Get core register regnum=0, name=r0, value=0x00000000
...
Debug: 2900 5635 arc.c:955 arc_save_context(): Get core register regnum=60, name=lp_count, value=0x900002c4
Debug: 2901 5635 arc.c:955 arc_save_context(): Get core register regnum=63, name=pcl, value=0xffffffff
Debug: 2902 5635 arc.c:970 arc_save_context(): Get aux register regnum=64, name=pc, value=0x900000b4
Debug: 2903 5635 arc.c:970 arc_save_context(): Get aux register regnum=65, name=lp_start, value=0x900000bc
Debug: 2904 5635 arc.c:970 arc_save_context(): Get aux register regnum=66, name=lp_end, value=0x00080801
Debug: 2905 5635 arc.c:970 arc_save_context(): Get aux register regnum=67, name=status32, value=0xffffffff

The off-by-one error is clearly visible. After the change, the register contents make much more sense:

Debug: 2832 3163 arc.c:955 arc_save_context(): Get core register regnum=0, name=r0, value=0x00000000
...
Debug: 2864 3163 arc.c:955 arc_save_context(): Get core register regnum=60, name=lp_count, value=0x00000000
Debug: 2865 3163 arc.c:955 arc_save_context(): Get core register regnum=63, name=pcl, value=0x900002c4
Debug: 2866 3163 arc.c:970 arc_save_context(): Get aux register regnum=64, name=pc, value=0x900002c6
Debug: 2867 3163 arc.c:970 arc_save_context(): Get aux register regnum=65, name=lp_start, value=0x900000b4
Debug: 2868 3163 arc.c:970 arc_save_context(): Get aux register regnum=66, name=lp_end, value=0x900000bc
Debug: 2869 3163 arc.c:970 arc_save_context(): Get aux register regnum=67, name=status32, value=0x00080801

While at it, simplify the function by e.g. removing a superfluous loop counter.


Change-Id: I8f2d79404707fbac4503af45b393ea73f91e6beb