### PR TITLE
target/arc: Fix off-by-one error in arc_save_context()

### DIFF
--- a/src/target/arc.c
+++ b/src/target/arc.c
@@ -846,21 +846,17 @@ static int arc_save_context(struct target *target)
 	memset(aux_addrs, 0xff, aux_regs_size);
 
 	for (i = 0; i < MIN(arc->num_core_regs, regs_to_scan); i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
-		if (!reg->valid && reg->exist) {
-			core_addrs[core_cnt] = arc_reg->arch_num;
-			core_cnt += 1;
-		}
+		if (!reg->valid && reg->exist)
+			core_addrs[core_cnt++] = arc_reg->arch_num;
 	}
 
 	for (i = arc->num_core_regs; i < regs_to_scan; i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
-		if (!reg->valid && reg->exist) {
-			aux_addrs[aux_cnt] = arc_reg->arch_num;
-			aux_cnt += 1;
-		}
+		if (!reg->valid && reg->exist)
+			aux_addrs[aux_cnt++] = arc_reg->arch_num;
 	}
 
 	/* Read data from target. */
@@ -884,30 +880,28 @@ static int arc_save_context(struct target *target)
 	/* Parse core regs */
 	core_cnt = 0;
 	for (i = 0; i < MIN(arc->num_core_regs, regs_to_scan); i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
 		if (!reg->valid && reg->exist) {
 			target_buffer_set_u32(target, reg->value, core_values[core_cnt]);
-			core_cnt += 1;
 			reg->valid = true;
 			reg->dirty = false;
 			LOG_DEBUG("Get core register regnum=%u, name=%s, value=0x%08" PRIx32,
-				i, arc_reg->name, core_values[core_cnt]);
+				i, arc_reg->name, core_values[core_cnt++]);
 		}
 	}
 
 	/* Parse aux regs */
 	aux_cnt = 0;
 	for (i = arc->num_core_regs; i < regs_to_scan; i++) {
-		struct reg *reg = &(reg_list[i]);
+		struct reg *reg = reg_list + i;
 		struct arc_reg_desc *arc_reg = reg->arch_info;
 		if (!reg->valid && reg->exist) {
 			target_buffer_set_u32(target, reg->value, aux_values[aux_cnt]);
-			aux_cnt += 1;
 			reg->valid = true;
 			reg->dirty = false;
 			LOG_DEBUG("Get aux register regnum=%u, name=%s, value=0x%08" PRIx32,
-				i, arc_reg->name, aux_values[aux_cnt]);
+				i, arc_reg->name, aux_values[aux_cnt++]);
 		}
 	}
 


### PR DESCRIPTION
While not affecting the function's main purpose, an error has crept into arc_save_context() that results in logging wrong register values when the debug level is 3 or more. For instance, when debugging a trivial program and halting at entry to main, the following values are printed to the log:

Debug: 2915 2020 arc.c:894 arc_save_context(): Get core register regnum=0, name=r0, value=0x0000000w
...
Debug: 2947 2020 arc.c:894 arc_save_context(): Get core register regnum=60, name=lp_count, value=0x900002d8
Debug: 2948 2020 arc.c:894 arc_save_context(): Get core register regnum=63, name=pcl, value=0xffffffff
Debug: 2949 2020 arc.c:909 arc_save_context(): Get aux register regnum=64, name=pc, value=0x900000b4
Debug: 2950 2020 arc.c:909 arc_save_context(): Get aux register regnum=65, name=lp_start, value=0x900000bc
Debug: 2951 2020 arc.c:909 arc_save_context(): Get aux register regnum=66, name=lp_end, value=0x00080801
Debug: 2952 2020 arc.c:909 arc_save_context(): Get aux register regnum=67, name=status32, value=0xffffffff

After the change, the register contents make much more sense:

Debug: 2923 3934 arc.c:889 arc_save_context(): Get core register regnum=0, name=r0, value=0x00000000
...
Debug: 2955 3934 arc.c:889 arc_save_context(): Get core register regnum=60, name=lp_count, value=0x00000000
Debug: 2956 3934 arc.c:889 arc_save_context(): Get core register regnum=63, name=pcl, value=0x900002d8
Debug: 2957 3934 arc.c:903 arc_save_context(): Get aux register regnum=64, name=pc, value=0x900002da
Debug: 2958 3934 arc.c:903 arc_save_context(): Get aux register regnum=65, name=lp_start, value=0x900000b4
Debug: 2959 3934 arc.c:903 arc_save_context(): Get aux register regnum=66, name=lp_end, value=0x900000bc
Debug: 2960 3934 arc.c:903 arc_save_context(): Get aux register regnum=67, name=status32, value=0x00080801

While at it, simplify a couple of expressions.


Change-Id: I8f2d79404707fbac4503af45b393ea73f91e6beb