### PR TITLE
target/arc: Do not invalidate icache when (un)setting breakpoints

### DIFF
--- a/src/target/arc.c
+++ b/src/target/arc.c
@@ -1577,9 +1577,6 @@ static int arc_set_breakpoint(struct target *target,
 		return ERROR_FAIL;
 	}
 
-	/* core instruction cache is now invalid. */
-	CHECK_RETVAL(arc_cache_invalidate(target));
-
 	return ERROR_OK;
 }
 
@@ -1661,9 +1658,6 @@ static int arc_unset_breakpoint(struct target *target,
 			LOG_DEBUG("ERROR: unsetting unknown breakpoint type");
 			return ERROR_FAIL;
 	}
-
-	/* core instruction cache is now invalid. */
-	CHECK_RETVAL(arc_cache_invalidate(target));
 
 	return retval;
 }


### PR DESCRIPTION
Currently, instruction cache is being invalidated in arc_{un,}set_breakpoint() regardless of whether the breakpoint's type is HW or SW. For SW breakpoints, this has no net effect as the caches are flushed prior to resuming execution anyway and is thus merely unnecessary; but for HW breakpoints this invalidation is not preceded by a flush and might lead to loss of data. This patch removes the invalidate() call altogether to correct this undesired behavior for HW breakpoints.

Change-Id: I3d252b97f01f1a1e2bf0eb8fb257bdab0c544bc2