### PR TITLE
target/arc: implement basic SMP support

### DIFF
--- a/tcl/board/snps_hsdk_smp.cfg
+++ b/tcl/board/snps_hsdk_smp.cfg
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#  Copyright (C) 2019, 2020 Synopsys, Inc.
+#  Anton Kolesov <anton.kolesov@synopsys.com>
+#  Didin Evgeniy <didin@synopsys.com>
+
+# Synopsys DesignWare ARC AXS103 Software Development Platform (HS38 cores)
+#
+
+# Configure JTAG cable
+# SDP has built-in FT2232 chip, which is similar to Digilent HS-1, except that
+# it uses channel B for JTAG, instead of channel A.
+source [find interface/ftdi/snps_sdp.cfg]
+adapter speed 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_hsdk_smp.cfg]
+
+# Initialize
+init
+reset halt
+

--- a/tcl/target/snps_hsdk_smp.cfg
+++ b/tcl/target/snps_hsdk_smp.cfg
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+#  Copyright (C) 2019,2020,2023 Synopsys, Inc.
+#  Anton Kolesov <anton.kolesov@synopsys.com>
+#  Didin Evgeniy <didin@synopsys.com>
+#  Artemiy Volkov <artemiy@synopsys.com>
+
+#
+# HS Development Kit SoC.
+#
+# Contains quad-core ARC HS38.
+#
+
+source [find cpu/arc/hs.tcl]
+
+# CHIPNAME will be used to choose core family (600, 700 or EM). As far as
+# OpenOCD is concerned EM and HS are identical.
+set _CHIPNAME arc-em
+
+# Set up global variables and a cpu description generation routine.
+#
+set _coreid 0
+set _dbgbase [expr {$_coreid << 13}]
+set _smp_targets ""
+
+proc setup_cpu {core_index expected_id} {
+	global _coreid
+	global _dbgbase
+	global _smp_targets
+	global _CHIPNAME
+
+	set _TARGETNAME $_CHIPNAME.cpu$core_index
+
+	jtag newtap $_CHIPNAME cpu$core_index -irlen 4 -ircapture 0x1 -expected-id $expected_id
+
+	target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME
+	$_TARGETNAME configure -coreid $_coreid
+	$_TARGETNAME configure -dbgbase $_dbgbase
+	# Flush L2$.
+	$_TARGETNAME configure -event reset-assert "arc_hs_reset $_TARGETNAME"
+
+	arc_hs_init_regs
+
+	# Enable L2 cache support for core 4.
+	$_TARGETNAME arc cache l2 auto 1
+
+	set _smp_targets "$_smp_targets $_TARGETNAME"
+	set _coreid [expr {$_coreid + 1}]
+	set _dbgbase [expr {$_coreid << 13}]
+}
+
+# OpenOCD discovers JTAG TAPs in reverse order.
+
+setup_cpu 4 0x200c24b1
+setup_cpu 3 0x200824b1
+setup_cpu 2 0x200424b1
+setup_cpu 1 0x200024b1
+
+eval "target smp $_smp_targets"


### PR DESCRIPTION
This patch adds support for SMP targets in arc_poll(), arc_halt(), and arc_resume(), which is just enough to be able to use arc-openocd for simple program execution ('load_image' followed by 'resume $addr') in SMP mode. Other SMP-aware functionality (e.g. breakpoints, single-stepping, gdb support) is left to be implemented in the future.

This has been previously committed to the Zephyr project's openocd repo[1], and currently allows us to run nightly testsuite runs on real HW with arc-openocd as the program runner.

Included in this patch are also snps_hsdk_smp.cfg configuration files for the ARCv2 HSDK boards, which are functionally equivalent to their snps_hsdk.cfg counterparts except for the SMP target registration at the end.

[1] https://github.com/zephyrproject-rtos/openocd/pull/25

Change-Id: I04bef83b51dd1e5daee01b9c0392da5f16106468