### PR TITLE
tcl: add configuration files for the ARC HSDK-4xD board

### DIFF
--- a/tcl/board/snps_hsdk_4xd.cfg
+++ b/tcl/board/snps_hsdk_4xd.cfg
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Copyright (C) 2023 Synopsys, Inc.
+# Artemiy Volkov <artemiy@synopsys.com>
+
+# Adapted from tcl/board/snps_hsdk.cfg.
+
+#
+# Synopsys DesignWare ARC HSDK Software Development Platform (HS47D cores)
+#
+
+source [find interface/ftdi/snps_sdp.cfg]
+adapter speed 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_hsdk_4xd.cfg]

--- a/tcl/target/snps_hsdk_4xd.cfg
+++ b/tcl/target/snps_hsdk_4xd.cfg
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Copyright (C) 2023 Synopsys, Inc.
+# Artemiy Volkov <artemiy@synopsys.com>
+
+# Adapted from tcl/target/snps_hsdk.cfg.
+
+#
+# HS Development Kit SoC.
+#
+# Contains quad-core ARC HS47D.
+#
+
+source [find cpu/arc/hs.tcl]
+
+set _coreid 0
+set _dbgbase [expr {$_coreid << 13}]
+
+# CHIPNAME will be used to choose core family (600, 700 or EM). As far as
+# OpenOCD is concerned EM and HS are identical.
+set _CHIPNAME arc-em
+
+
+proc setup_cpu {core_index expected_id} {
+	global _coreid
+	global _dbgbase
+	global _CHIPNAME
+
+	set _TARGETNAME $_CHIPNAME.cpu$core_index
+	jtag newtap $_CHIPNAME cpu$core_index -irlen 4 -ircapture 0x1 -expected-id $expected_id
+
+	target create $_TARGETNAME arcv2 -chain-position $_TARGETNAME
+	$_TARGETNAME configure -coreid $_coreid
+	$_TARGETNAME configure -dbgbase $_dbgbase
+	$_TARGETNAME configure -event reset-assert "arc_hs_reset $_TARGETNAME"
+
+	arc_hs_init_regs
+
+	$_TARGETNAME arc cache l2 auto 1
+
+	set _coreid [expr {$_coreid + 1}]
+	set _dbgbase [expr {$_coreid << 13}]
+}
+
+# OpenOCD discovers JTAG TAPs in reverse order.
+
+setup_cpu 4 0x100c54b1
+setup_cpu 3 0x100854b1
+setup_cpu 2 0x100454b1
+setup_cpu 1 0x100054b1


### PR DESCRIPTION
This commit provides startup files for the Synopsys DesignWare ARC HSDK-4xD board. These have been adapted from the corresponding snps_hsdk.cfg files, the only functional change being the JTAG IDs for the new board's CPU cores.

Change-Id: I19a0cd13bc09de90cfe2a7cccf1239e459fd8077